### PR TITLE
Missing Touch-Up event creates zombie timer

### DIFF
--- a/NBTouchAndHoldButton.m
+++ b/NBTouchAndHoldButton.m
@@ -67,7 +67,7 @@
 
 - (void) sourceTouchDown:(UIButton*) sender {
     SEL selector;
-    if (strcmp([repeateSelectorAsValue objCType], @encode(SEL)) == 0) {
+    if ((holdTimer == nil) && (strcmp([repeateSelectorAsValue objCType], @encode(SEL)) == 0)) {
         [repeateSelectorAsValue getValue:&selector];
         holdTimer = [NSTimer scheduledTimerWithTimeInterval:dt  target:targetOfRepeatSel selector:selector userInfo:nil repeats: YES];
     }


### PR DESCRIPTION
When you tap on a TouchAndHoldButton very quickly multiple times then
sometimes the "Touch-Up" event is missing. (I could reproduce this on
iOS8, but only on a real device, not in the simulator.)
In that case a new holdTimer gets created leaving the previous one in a
zombie state.
I.e. the previous holdTimer continues firing events and will not stop
until you force quit the app.

Fix:
Before creating a new holdTimer check if there is already one.
